### PR TITLE
fixed wrong header name in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 project(folf-namespace
-        VERSION 1.0.2
+        VERSION 1.0.3
         DESCRIPTION "FOLF - A C++ library developed by a fox and a wolf for testing and making development easier!"
         HOMEPAGE_URL "https://github.com/FOLF-projects/folf-namespace"
         LANGUAGES CXX)

--- a/folf/CMakeLists.txt
+++ b/folf/CMakeLists.txt
@@ -20,5 +20,5 @@ set_target_properties(folf-namespace PROPERTIES
         PUBLIC_HEADER "folf/algorithms.hpp;
                        folf/info.hpp;
                        folf/conTools.hpp;
-                       folf/numTools.hpp;
+                       folf/calcTools.hpp;
                        folf/timeTools.hpp")


### PR DESCRIPTION
Fixed folf/calcTool.hpp still named folf/numTool.hpp in cmake, which makes it impossible to include that file.